### PR TITLE
Backtick support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "juokse",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Batch processor with Python like syntax",
   "author": "Rauli Laine",
   "license": "BSD-2-Clause",

--- a/src/ast/token.test.ts
+++ b/src/ast/token.test.ts
@@ -3,10 +3,12 @@ import { Position } from "./position";
 import { Word, WordType, WordVisitor, visitWord } from "./token";
 
 describe("visitWord()", () => {
+  const visitBacktick = jest.fn();
   const visitDoubleQuote = jest.fn();
   const visitSingleQuote = jest.fn();
   const visitSimpleWord = jest.fn();
   const visitor: Readonly<WordVisitor<undefined, undefined>> = {
+    visitBacktick,
     visitDoubleQuote,
     visitSingleQuote,
     visitWord: visitSimpleWord,
@@ -18,9 +20,16 @@ describe("visitWord()", () => {
   };
 
   beforeEach(() => {
+    visitBacktick.mockReset();
     visitDoubleQuote.mockReset();
     visitSingleQuote.mockReset();
     visitSimpleWord.mockReset();
+  });
+
+  it("should visit backtick", () => {
+    visitWord(visitor, { position, type: "Backtick", text: "test" }, undefined);
+
+    expect(visitBacktick).toBeCalled();
   });
 
   it("should visit double quoted string", () => {

--- a/src/ast/token.ts
+++ b/src/ast/token.ts
@@ -1,7 +1,7 @@
 import { JuokseError } from "../error";
 import { Position } from "./position";
 
-export type WordType = "DoubleQuote" | "SingleQuote" | "Word";
+export type WordType = "Backtick" | "DoubleQuote" | "SingleQuote" | "Word";
 
 export type TokenType =
   | WordType
@@ -28,6 +28,7 @@ export type Word = Token & {
 };
 
 export type WordVisitor<R, A = undefined> = {
+  visitBacktick: (word: Word, arg: A) => R;
   visitDoubleQuote: (word: Word, arg: A) => R;
   visitSingleQuote: (word: Word, arg: A) => R;
   visitWord: (word: Word, arg: A) => R;
@@ -39,6 +40,9 @@ export const visitWord = <R, A = undefined>(
   arg: A
 ): R => {
   switch (word.type) {
+    case "Backtick":
+      return visitor.visitBacktick(word, arg);
+
     case "DoubleQuote":
       return visitor.visitDoubleQuote(word, arg);
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -21,7 +21,7 @@ export type ExecutionResult = {
  * Class which represents context of an script execution.
  */
 export class Context extends EventEmitter {
-  public readonly stdout: PassThrough;
+  public stdout: PassThrough;
   public readonly stderr: PassThrough;
   public readonly stdin: PassThrough;
   public readonly environment: Record<string, string>;

--- a/src/execute.ts
+++ b/src/execute.ts
@@ -179,23 +179,23 @@ const executeLoopBody = async (
   }
 };
 
-export const executeScript = (
+export const executeScript = async (
   context: Context,
   script: Statement[],
   onError: (error: Error) => void
-): void => {
+): Promise<void> => {
   let index = 0;
-  const executeNextStatement = (): void => {
+  const executeNextStatement = async (): Promise<void> => {
     const statement = script[index++];
 
     if (statement) {
-      visitStatement(visitor, statement, context)
+      await visitStatement(visitor, statement, context)
         .catch(onError)
         .then(executeNextStatement);
     }
   };
 
   if (script.length > 0) {
-    executeNextStatement();
+    await executeNextStatement();
   }
 };

--- a/src/lexer/lexer.ts
+++ b/src/lexer/lexer.ts
@@ -104,7 +104,12 @@ const lexString = (state: State): Word => {
 
   return {
     position,
-    type: separator === '"' ? "DoubleQuote" : "SingleQuote",
+    type:
+      separator === "`"
+        ? "Backtick"
+        : separator === '"'
+        ? "DoubleQuote"
+        : "SingleQuote",
     text,
   };
 };
@@ -248,7 +253,7 @@ const lexLogicalLine = (
 
     // TODO: Escaped new lines.
 
-    if (state.peek("'", '"')) {
+    if (state.peek("'", '"', "`")) {
       tokens.push(lexString(state));
       continue;
     }

--- a/src/parser/state.ts
+++ b/src/parser/state.ts
@@ -1,7 +1,12 @@
 import { Position, Token, TokenType, Word } from "../ast";
 import { JuokseError } from "../error";
 
-const WORD_TYPES = new Set<TokenType>(["DoubleQuote", "SingleQuote", "Word"]);
+const WORD_TYPES = new Set<TokenType>([
+  "Backtick",
+  "DoubleQuote",
+  "SingleQuote",
+  "Word",
+]);
 
 export class State {
   public readonly tokens: Token[];


### PR DESCRIPTION
Add rudimentary support for backticks, which execute commands and store
their output in a string. This implementation is not optimized and is
meant to be the initial implementation.