### PR TITLE
Strip trailing whitespace from backtick expansion

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "juokse",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Batch processor with Python like syntax",
   "author": "Rauli Laine",
   "license": "BSD-2-Clause",

--- a/src/expand.ts
+++ b/src/expand.ts
@@ -1,4 +1,5 @@
 import { globSync, hasMagic } from "glob";
+import { trimEnd } from "lodash";
 import { PassThrough } from "stream";
 
 import { visitWord, Word, WordVisitor } from "./ast";
@@ -40,7 +41,7 @@ const expandVisitor: WordVisitor<Promise<string[]>, Context> = {
       throw subshellError;
     }
 
-    return [buffer];
+    return [trimEnd(buffer)];
   },
 
   async visitDoubleQuote(word: Word, context: Context): Promise<string[]> {


### PR DESCRIPTION
Trailing whitespace such as new lines should be stripped from backtick expansion.