### PR TITLE
Add very simple interactive mode

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@ import stripAnsi from "strip-ansi";
 import { compile } from "./compiler";
 import { Context } from "./context";
 import { executeScript } from "./execute";
+import { runInteractive } from "./interactive";
 import { ExitStatus } from "./status";
 
 type CommandLineOptions = {
@@ -139,6 +140,8 @@ export const run = () => {
       fs.readFileSync(options.filename, "utf-8"),
       options.filename
     );
+  } else if (process.stdin.isTTY) {
+    runInteractive(context);
   } else {
     let source = "";
 

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -8,7 +8,7 @@ export const compile = (
 ): Promise<Statement[]> =>
   new Promise<Statement[]>((resolve, reject) => {
     try {
-      resolve(parse(lex(filename, source)));
+      resolve(parse(lex(filename, 1, source)));
     } catch (err) {
       reject(err);
     }

--- a/src/interactive.ts
+++ b/src/interactive.ts
@@ -1,0 +1,43 @@
+import * as readline from "readline";
+
+import { Statement } from "./ast";
+import { Context } from "./context";
+import { executeScript } from "./execute";
+import { lex } from "./lexer";
+import { parse } from "./parser";
+import { ExitStatus } from "./status";
+
+export const runInteractive = (context: Context) => {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    prompt: "juokse:1> ",
+  });
+  let lineNumber = 1;
+
+  rl.on("line", (source) => {
+    let script: Statement[];
+
+    try {
+      script = parse(lex("<stdin>", lineNumber++, source));
+    } catch (err) {
+      console.error(err);
+      return;
+    }
+
+    executeScript(context, script)
+      .catch((err) => {
+        console.error(err);
+      })
+      .finally(() => {
+        rl.setPrompt(`juokse:${lineNumber}> `);
+        rl.prompt();
+      });
+  });
+
+  rl.on("close", () => {
+    process.exit(ExitStatus.OK);
+  });
+
+  rl.prompt();
+};

--- a/src/lexer/lexer.test.ts
+++ b/src/lexer/lexer.test.ts
@@ -3,19 +3,19 @@ import { lex } from "./lexer";
 
 describe("lex()", () => {
   it("should return nothing when there is nothing to lex", () => {
-    expect(lex("test", "")).toHaveLength(0);
+    expect(lex("test", 1, "")).toHaveLength(0);
   });
 
   it("should ignore comments", () => {
-    expect(lex("test", "# This should be ignored.\n")).toHaveLength(0);
+    expect(lex("test", 1, "# This should be ignored.\n")).toHaveLength(0);
   });
 
   it("should ignore empty lines", () => {
-    expect(lex("test", "  \t  \n")).toHaveLength(0);
+    expect(lex("test", 1, "  \t  \n")).toHaveLength(0);
   });
 
   it("should be able to detect when indentation is increased", () => {
-    expect(lex("test", "  foo")).toEqual([
+    expect(lex("test", 1, "  foo")).toEqual([
       {
         position: {
           filename: "test",
@@ -53,7 +53,7 @@ describe("lex()", () => {
   });
 
   it("should be able to lex simple words", () => {
-    expect(lex("test", "foo bar")).toEqual([
+    expect(lex("test", 1, "foo bar")).toEqual([
       {
         position: {
           filename: "test",
@@ -76,7 +76,7 @@ describe("lex()", () => {
   });
 
   it("should parse escape sequences in simple words", () => {
-    expect(lex("test", "a\\u0030")).toEqual([
+    expect(lex("test", 1, "a\\u0030")).toEqual([
       {
         position: {
           filename: "test",
@@ -98,12 +98,12 @@ describe("lex()", () => {
   ])(
     "should be able to distinguish reserved keywords from simple words",
     (input, expectedType) => {
-      expect(lex("test", input)).toHaveProperty([0, "type"], expectedType);
+      expect(lex("test", 1, input)).toHaveProperty([0, "type"], expectedType);
     }
   );
 
   it.each([":", ";"])("should be able to lex separators", (separator) => {
-    expect(lex("test", separator)).toEqual([
+    expect(lex("test", 1, separator)).toEqual([
       {
         position: {
           filename: "test",
@@ -116,7 +116,7 @@ describe("lex()", () => {
   });
 
   it("should be able to lex double quoted strings", () => {
-    expect(lex("test", '"foo"')).toEqual([
+    expect(lex("test", 1, '"foo"')).toEqual([
       {
         position: {
           filename: "test",
@@ -130,7 +130,7 @@ describe("lex()", () => {
   });
 
   it("should be able to lex single quoted strings", () => {
-    expect(lex("test", "'foo'")).toEqual([
+    expect(lex("test", 1, "'foo'")).toEqual([
       {
         position: {
           filename: "test",
@@ -144,7 +144,7 @@ describe("lex()", () => {
   });
 
   it("should parse escape sequences inside double quoted strings", () => {
-    expect(lex("test", '"\\u0030"')).toEqual([
+    expect(lex("test", 1, '"\\u0030"')).toEqual([
       {
         position: {
           filename: "test",
@@ -158,7 +158,7 @@ describe("lex()", () => {
   });
 
   it("should not parse escape sequences inside single quoted strings", () => {
-    expect(lex("test", "'\\u0030'")).toEqual([
+    expect(lex("test", 1, "'\\u0030'")).toEqual([
       {
         position: {
           filename: "test",
@@ -172,6 +172,6 @@ describe("lex()", () => {
   });
 
   it("should throw exception if unable to parse an escape sequence", () => {
-    expect(() => lex("test", '"\\z"')).toThrowError(JuokseError);
+    expect(() => lex("test", 1, '"\\z"')).toThrowError(JuokseError);
   });
 });

--- a/src/lexer/lexer.ts
+++ b/src/lexer/lexer.ts
@@ -262,8 +262,12 @@ const lexLogicalLine = (
   }
 };
 
-export const lex = (filename: string, source: string): Token[] => {
-  const state = new State(filename, source);
+export const lex = (
+  filename: string,
+  line: number,
+  source: string
+): Token[] => {
+  const state = new State(filename, line, source);
   const tokens: Token[] = [];
   const indentStack = new Stack<number>();
 

--- a/src/lexer/state.test.ts
+++ b/src/lexer/state.test.ts
@@ -4,23 +4,23 @@ import { State } from "./state";
 describe("class State", () => {
   describe("eof()", () => {
     it("should return `true` if there are no more characters to be read", () =>
-      expect(new State("test", "").eof()).toBe(true));
+      expect(new State("test", 1, "").eof()).toBe(true));
 
     it("should return `false` if there are more characters to be read", () =>
-      expect(new State("test", "a").eof()).toBe(false));
+      expect(new State("test", 1, "a").eof()).toBe(false));
   });
 
   describe("current()", () => {
     it("should return next character if there are more characters to be read", () =>
-      expect(new State("test", "a").current()).toBe("a"));
+      expect(new State("test", 1, "a").current()).toBe("a"));
 
     it("should throw error if there are no more characters to be read", () =>
-      expect(() => new State("test", "").current()).toThrow(JuokseError));
+      expect(() => new State("test", 1, "").current()).toThrow(JuokseError));
   });
 
   describe("peek()", () => {
     it("should return `false` if there are no more characters to be read", () =>
-      expect(new State("test", "").peek("a")).toBe(false));
+      expect(new State("test", 1, "").peek("a")).toBe(false));
 
     it.each([
       [true, "a", "a"],
@@ -32,16 +32,16 @@ describe("class State", () => {
     ])(
       "should return %p when the next character is %p and given pattern is %p",
       (expectedResult, input, pattern) =>
-        expect(new State("test", input).peek(pattern)).toBe(expectedResult)
+        expect(new State("test", 1, input).peek(pattern)).toBe(expectedResult)
     );
   });
 
   describe("peekRead()", () => {
     it("should return false if the next character does not match given pattern", () =>
-      expect(new State("test", "a").peekRead("b")).toBe(false));
+      expect(new State("test", 1, "a").peekRead("b")).toBe(false));
 
     it("should return true and advance when the next character matches given pattern", () => {
-      const state = new State("test", "a");
+      const state = new State("test", 1, "a");
 
       expect(state.peekRead("a")).toBe(true);
       expect(state).toHaveProperty("offset", 1);
@@ -50,15 +50,15 @@ describe("class State", () => {
 
   describe("advance()", () => {
     it("should throw error if there are no more characters to be read", () =>
-      expect(() => new State("test", "").advance()).toThrow(JuokseError));
+      expect(() => new State("test", 1, "").advance()).toThrow(JuokseError));
 
     it("should return next character from the source code", () =>
-      expect(new State("test", "a").advance()).toBe("a"));
+      expect(new State("test", 1, "a").advance()).toBe("a"));
 
     it.each(["\n", "\r"])(
       "should increase line number when new line is encountered",
       (input) => {
-        const state = new State("test", input);
+        const state = new State("test", 1, input);
 
         expect(state.advance()).toBe("\n");
         expect(state).toHaveProperty(["position", "line"], 2);

--- a/src/lexer/state.ts
+++ b/src/lexer/state.ts
@@ -9,10 +9,10 @@ export class State {
   private readonly source: string;
   private offset: number;
 
-  public constructor(filename: string, source: string) {
+  public constructor(filename: string, line: number, source: string) {
     this.position = {
       filename,
-      line: 1,
+      line,
       column: 1,
     };
     this.source = source;

--- a/src/parser/parser.test.ts
+++ b/src/parser/parser.test.ts
@@ -22,7 +22,7 @@ const mockPosition: Readonly<Position> = {
 };
 
 const createState = (source: string) =>
-  new State(lex(mockPosition.filename, source));
+  new State(lex(mockPosition.filename, 1, source));
 
 describe("parseBlockStatement()", () => {
   it("should require indentation after new line", () =>


### PR DESCRIPTION
Add interactive mode like many other scripting languages have, where you have an kind of REPL interface to run simple commands.

This is very very simple at the moment and cannot be used with block statements at the moment. I will eventually extend it to work the same way than Python interactive shell for example has.